### PR TITLE
chore(build): pin Firefox version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - polymer install
 node_js: node
 addons:
-  firefox: latest
+  firefox: '66.0'
   chrome: stable
 script:
   - xvfb-run polymer test


### PR DESCRIPTION
Pin Firefox version to v66.0 because from v67.0 and higher
Geckodriver v.0.24.0 is required and Polymer CLI does not
use it yet.