### PR TITLE
fix(style): image not rounded

### DIFF
--- a/hostabee-profile-picture.html
+++ b/hostabee-profile-picture.html
@@ -18,6 +18,7 @@
       img {
         height: 50px;
         width: 50px;
+        border-radius: 50%;
       }
 
       .initials {


### PR DESCRIPTION
Before this commit the image was not rounded when using square image.
Not it is.

fixes #5